### PR TITLE
chore(security): adopt base-ci v2026.4 trustedDependencies whitelist (Shai-Hulud defense)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   quality:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.1
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
     with:
+      ignore-scripts: true
+      trusted-native-deps: "better-sqlite3"
+      extra-install-dirs: "packages/core"
       test-command: "bun run test:coverage"
       typecheck-command: "true"
       enable-security: "true"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,5 +29,8 @@
     "@types/better-sqlite3": "^7.6.13",
     "drizzle-kit": "^0.31.9",
     "typescript": "^5.9.3"
-  }
+  },
+  "trustedDependencies": [
+    "better-sqlite3"
+  ]
 }


### PR DESCRIPTION
Bumps base-ci to v2026.4 (trustedDependencies model, replaces broken v2026.3 `bun pm trust` approach). Declares trustedDependencies in packages/core/package.json so bun runs postinstall only for listed native deps (better-sqlite3).