### PR TITLE
chore(ci): pin base-ci reusable workflow to v2026.5 SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   quality:
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5
     with:
       trusted-native-deps: "better-sqlite3,esbuild,unrs-resolver"
       test-command: "bun run test:coverage"


### PR DESCRIPTION
## chore(ci): pin base-ci reusable workflow to v2026.5 SHA

Pins `nocoo/base-ci/.github/workflows/bun-quality.yml` from floating tag `@v2026.4` to the immutable commit SHA `aec4adc1a817c56790d1698329ef9398a15a754a` (v2026.5).

### Why

Floating `@v2026.x` tags can be silently retargeted (re-tag or force-push in `nocoo/base-ci`) and violate supply-chain best practice. Pinning to a 40-char commit SHA makes the reusable workflow reference byte-immutable so a compromise of base-ci cannot inject code into arena's CI.

### Change

```diff
-    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@v2026.4
+    uses: nocoo/base-ci/.github/workflows/bun-quality.yml@aec4adc1a817c56790d1698329ef9398a15a754a  # v2026.5
```

Trailing two-space + `# v2026.5` marker preserved so future readers can map SHA → version at a glance.

### Verification

- Only `.github/workflows/ci.yml` references `nocoo/base-ci`; no other workflow files needed changes.
- `git ls-remote https://github.com/nocoo/base-ci refs/tags/v2026.5^{}` resolves to `aec4adc1a817c56790d1698329ef9398a15a754a`.
- `actionlint .github/workflows/*.yml` clean.
- `rg "nocoo/base-ci/.+@v2026\.[0-9]+" .github/workflows` → no residual floating refs.

Refs: STU-924
