### PR TITLE
chore: add root .npmrc for supply chain security baseline

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,21 @@
+# ===== Supply chain security =====
+# Pin to official npm registry (防钓鱼源)
+registry=https://registry.npmjs.org/
+
+# ===== Lockfile integrity =====
+# Pin exact versions on npm install (防 minor/patch 漂移)
+save-exact=true
+# Always maintain package-lock (防 lockfile 被删)
+package-lock=true
+
+# ===== Environment consistency =====
+# Enforce engines field (防 Node/npm 版本不匹配)
+engine-strict=true
+
+# ===== Audit strategy =====
+# Auto-run audit on install
+audit=true
+# Fail install on high+ severity
+audit-level=high
+# Silence funding output (noise reduction)
+fund=false


### PR DESCRIPTION
Adds root `.npmrc` per STU-1528: pin official npm registry, enforce lockfile integrity (`save-exact`, `package-lock`), `engine-strict`, and enable `audit` at `level=high`.

- One atomic commit; no `package.json`/lockfile/CI/hook edits; no install run.
- Verbatim match with the issue template (comments, blank lines, EOF newline preserved).

Reviewed by Reviewer-02 (see [STU-1528](https://github.com/) issue thread).

Issue: STU-1528